### PR TITLE
agent: Fix possible segfault on adding idle calls

### DIFF
--- a/mosqagent.c
+++ b/mosqagent.c
@@ -199,8 +199,8 @@ int mosqagent_add_idle_call(struct mosqagent *agent,
         // find tail
         struct mosqagent_idle_list *e;
         e = agent->idle;
-        while (e)
-        e = e->next;
+        while (e->next)
+            e = e->next;
 
         // add new entry
         e->next = entry;


### PR DESCRIPTION
When adding more than one idle call the agent must have failed before.
The while loop condition tested on the entry itself, which ended up on
NULL when the last entry was found, so the following assignement on
e->next must have failed always. Not tested, but cppchecked complained
like this:

> Either the condition 'e' is redundant or there is possible null
> pointer dereference: e.

Now the while condition tests directly on the next member. If it's
already NULL on the first element, fine, it's set to the new entry then,
else the loops runs until the entry with next set to NULL is found,
which is then set to the new entry.

Fixed the wrong indentation while at it.

Signed-off-by: Alexander Dahl <post@lespocky.de>