### PR TITLE
Memory Object handling with De-Allocator

### DIFF
--- a/mosqagent.c
+++ b/mosqagent.c
@@ -16,6 +16,41 @@
 
 #include "mosqhelper.h"
 
+
+void* mqtta_mo_ptr(const struct mqtta_memory_object *mo)
+{
+    return mo ? mo->ptr : NULL;
+}
+
+struct mqtta_memory_object* mqtta_mo_move(struct mqtta_memory_object *mo,
+                                          void *ptr,
+                                          mqtta_mo_deallocator *deallocator)
+{
+    if (mo) {
+        mo->ptr = ptr;
+        mo->deallocator = deallocator;
+    }
+
+    return mo;
+}
+
+struct mqtta_memory_object* mqtta_mo_set(struct mqtta_memory_object *mo,
+                                         void *ptr)
+{
+    // same as move without de-allocator
+    return mqtta_mo_move(mo, ptr, NULL);
+}
+
+void mqtta_mo_free(struct mqtta_memory_object *mo)
+{
+    if (mo && mo->ptr && mo->deallocator) {
+        mo->deallocator(mo->ptr);
+        mo->ptr = NULL;
+        //mo->deallocator = NULL;  // <-- not necessary
+    }
+}
+
+
 struct mosqagent_idle_list {
     struct mosqagent_idle_list *next;
     mosqagent_idle_call idle_call;

--- a/mosqagent.h
+++ b/mosqagent.h
@@ -14,6 +14,95 @@
 struct mosqagent_idle_list;
 struct mosqagent_config;
 
+
+/**
+ * \brief De-allocator function pointer
+ *
+ * The de-allocator is responsible for cleaning up a pointer and possible
+ * heap structures in the pointed-to struct. The exact handling is based
+ * on the struct, so the user (or the library) has to provide the correct
+ * de-allocator for each memory object.
+ *
+ * Providing `NULL` as de-allocator reference will be interpreted as
+ * "no de-allocation", i.e. the object will be left alone. Use this for stack
+ * pointers of if clean-up is handled somewhere else.
+ *
+ * \note The de-allocator is also responsible for cleaning up the pointed-to
+ * memory. The pendant for `malloc`-created objects would be a pointer to
+ * `free`.
+ */
+typedef void (mqtta_mo_deallocator)(void*);
+
+/**
+ * \brief A memory object that stores ownership information.
+ *
+ * Never manipulate the values directly! Always use `mqtta_mo_move` and
+ * `mqtta_mo_set` to change pointers. Ownership information is managed
+ * automatically by these functions.
+ */
+struct mqtta_memory_object {
+    void *ptr;
+    mqtta_mo_deallocator *deallocator;
+};
+
+/**
+ * \brief Get the pointer from a memory object.
+ */
+void* mqtta_mo_ptr(const struct mqtta_memory_object *mo);
+
+/**
+ * \brief Set the pointer and transfer ownership by providing a de-allocator.
+ *
+ * Ownership transfer implies that the pointer will be managed be the entity
+ * owning the memory object, i.e. the pointer should not be manipulated
+ * afterwards, especially free must not be called. The new owner will call
+ * the de-allocator when the memory object is no longer used.
+ *
+ * Validity of the pointer is tied to the implementation of the functions using
+ * the memory object.
+ *
+ * \returns the pointer provided for `mo` to enable function chaining.
+ *
+ * \warning Never transfer ownership for stack pointers and global variables!
+ *
+ * \note Provding a `NULL` de-allocator is equivalent to not transferring
+ *       ownership, i.e. the memory object will not be freed.
+ * \note Provide `free` as the standard de-allocator for `malloc`-created
+ *       objects.
+ */
+struct mqtta_memory_object* mqtta_mo_move(struct mqtta_memory_object *mo,
+                                          void *ptr,
+                                          mqtta_mo_deallocator *deallocator);
+
+/**
+ * \brief Set the pointer, but do not move ownership.
+ *
+ * The pointer in the memory object is set, but ownership remains with the
+ * caller. The pointer will not be manipulated by the entity owning the memory
+ * object, especially free will not be called.
+ *
+ * The caller has to ensure that the pointer is valid as long as the entity
+ * owning the memory object will need it.
+ *
+ * Use this function for stack pointers and global variables.
+ *
+ * \returns the pointer provided for `mo` to enable function chaining.
+ */
+struct mqtta_memory_object* mqtta_mo_set(struct mqtta_memory_object *mo,
+                                         void *ptr);
+
+/**
+ * \brief Free the memory object.
+ *
+ * The de-allocator will be called if provided and the internal pointer is
+ * not `NULL`, otherwise nothing happens.
+ *
+ * Safe to call multiple times, but not before initialization
+ * (might point anywhere).
+ */
+void mqtta_mo_free(struct mqtta_memory_object *mo);
+
+
 struct mosqagent {
     struct mosqagent_config *config;
 

--- a/mosqagent.h
+++ b/mosqagent.h
@@ -104,7 +104,7 @@ void mqtta_mo_free(struct mqtta_memory_object *mo);
 
 
 struct mosqagent {
-    struct mosqagent_config *config;
+    struct mqtta_memory_object config_mo;
 
     struct mosqagent_idle_list *idle;
 
@@ -170,6 +170,44 @@ struct mosqagent_config {
  */
 int mqtta_load_configuration(struct mosqagent *agent,
                              const char* filepath);
+
+/**
+ * \brief Set a configuration, but keep ownership.
+ *
+ * Use this if the configuration struct is a stack pointer or global variable.
+ */
+void mqtta_set_configuration(struct mosqagent *agent,
+                            struct mosqagent_config* config);
+
+/**
+ * \brief Set a configuration and transfer ownership.
+ *
+ * Use this if the configuration is a heap object and the agent should
+ * destroy the configuration on clean-up.
+ */
+void mqtta_move_configuration(struct mosqagent *agent,
+                             struct mosqagent_config* config);
+
+/**
+ * \brief Dispose of a configuration object.
+ *
+ * Note: This frees the configuration object, not a memory object struc.
+ * Ownership is not relevant for this function!
+ *
+ * \note Call this on stack pointers.
+ */
+void mqtta_dispose_configuration(struct mosqagent_config *config);
+
+/**
+ * \brief (Heap) De-allocator for configuration objects
+ *
+ * Frees the __char*__ fields and then the struct itself.
+ *
+ * \warning Only use with heap objects where a call to __free__ is safe!
+ */
+void mqtta_configuration_deallocator(void *config);
+
+struct mosqagent_config* mqtta_get_configuration(const struct mosqagent *agent);
 
 
 typedef struct mosqagent_result* (*mosqagent_idle_call)(struct mosqagent*);

--- a/mqtt-clock.c
+++ b/mqtt-clock.c
@@ -200,15 +200,15 @@ int main(int argc, char *argv[]) {
     }
 
     printf("Agent configuration:\n"
-           "\tName    %s\n"
-           "\tBroker  %s:%d\n",
-           agent->config->client_name,
-           agent->config->host,
-           agent->config->port);
+        "\tName    %s\n"
+        "\tBroker  %s:%d\n",
+        mqtta_get_configuration(agent)->client_name,
+        mqtta_get_configuration(agent)->host,
+        mqtta_get_configuration(agent)->port);
 
   // initialize the system logging
 #ifdef WITH_SYSLOG
-  openlog(agent->config->client_name, LOG_CONS | LOG_PID, LOG_USER);
+    openlog(mqtta_get_configuration(agent)->client_name, LOG_CONS | LOG_PID, LOG_USER);
 #endif
   syslog(LOG_INFO, "MQTT Clock serivce started.");
 


### PR DESCRIPTION
This PR is a continuation of #10 with an adapted API for pointer handling. Instead of an ownership statement, a de-allocation function can be provided for each memory object.

The changes aim towards #9, the remaining features will be added after a review.