### PR TITLE
Api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,16 @@ find_library(CONFIG_LIBRARY NAMES config)
 #find_library(POPT_LIBRARY NAMES popt)
 find_library(MOSQUITTO_LIBRARY NAMES mosquitto)
 
+# Headers
+configure_file(
+    mqtta-build.h.in
+    mqtta-build.h
+    @ONLY
+)
+include_directories(
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 add_executable(mqtt-clock
 mqtt-clock.c
 mosqagent.c

--- a/mosqagent.c
+++ b/mosqagent.c
@@ -15,6 +15,7 @@
 #include <mosquitto.h>
 
 #include "mosqhelper.h"
+#include "mqtta-build.h"
 
 
 void* mqtta_mo_ptr(const struct mqtta_memory_object *mo)
@@ -438,4 +439,9 @@ int mosqagent_idle(struct mosqagent *agent)
 const char* mosqagent_strerror(int mosq_errno)
 {
     return mosquitto_strerror(mosq_errno);
+}
+
+const char* mqtta_version( void )
+{
+    return MQTTA_VERSION;
 }

--- a/mosqagent.h
+++ b/mosqagent.h
@@ -122,8 +122,8 @@ struct mqtta_message {
 
 struct mqtta_message* mqtta_create_message(const char* topic,
                                            const char* payload,
-                                           const int qos,
-                                           const bool retain);
+                                           int qos,
+                                           bool retain);
 
 int mqtta_send_message(struct mosqagent* agent,
                        struct mqtta_message *msg);

--- a/mosqagent.h
+++ b/mosqagent.h
@@ -227,3 +227,5 @@ int mosqagent_add_idle_call(struct mosqagent *agent,
 int mosqagent_idle(struct mosqagent *agent);
 
 const char* mosqagent_strerror(int mosq_errno);
+
+const char* mqtta_version( void );

--- a/mosqhelper.h
+++ b/mosqhelper.h
@@ -16,8 +16,8 @@ int mqtt_init(const char* clientname,
 
 int mqtt_connect(struct mosquitto *mosq,
                  const char* host,
-		 const int port,
-		 const int retries);
+                 int port,
+                 int retries);
 
 int mqtt_loop(struct mosquitto *mosq);
 

--- a/mqtta-build.h.in
+++ b/mqtta-build.h.in
@@ -1,0 +1,15 @@
+/*******************************************************************//**
+ * \file		mqtta-build.h
+ *
+ * \brief		Stuff set by the build system.
+ *
+ * \author		Alexander Dahl <alex@netz39.de>
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * \copyright	2017 Alexander Dahl, Netz39 e.V.
+ **********************************************************************/
+
+#pragma once
+
+#define MQTTA_VERSION               "v@PROJECT_VERSION@"


### PR DESCRIPTION
* 9f2d1e70f6649ede06f8bf351f172e926e91f36c changes the API slightly and drops const where not necessary. It is about to discuss, if it should be removed in definition as well?
* a47ecf3dcf7641f02882236ea9875a1c694b26e9 is trivial and not yet very useful, but will come in handy later when adding options like `--version` to the agents.