### PR TITLE
build: lib: Use target dependent include directories

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,25 +1,25 @@
 #
-# 2017,2018 Stefan Haun, Netz39 e.V., and mqtta contributors
+# 2017–2019 Stefan Haun, Netz39 e.V., and mqtta contributors
 #
 # SPDX-License-Identifier: MIT
 # License-Filename: LICENSES/MIT.txt
 #
 
-include_directories(
-	"${PROJECT_SOURCE_DIR}/include/mqtt-tools"
-    "${PROJECT_BINARY_DIR}/include/mqtt-tools"
-)
-
 # mosqhelper
 add_library(mosqhelper
     mosqhelper.c
 )
+add_library(mqtta::mosqhelper ALIAS mosqhelper)
 set_target_properties(mosqhelper PROPERTIES
     OUTPUT_NAME         mosqhelper
     SOVERSION           ${PROJECT_VERSION_MAJOR}
     VERSION             ${PROJECT_VERSION}
     C_STANDARD          99
     C_STANDARD_REQUIRED ON
+)
+target_include_directories(mosqhelper
+	PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 target_link_libraries(mosqhelper
     "${MOSQUITTO_LIBRARY}"
@@ -34,6 +34,7 @@ install(TARGETS mosqhelper
 add_library(mqtta
     mqtta.c
 )
+add_library(mqtta::mqtta ALIAS mqtta)
 set_target_properties(mqtta PROPERTIES
     OUTPUT_NAME         mqtta
     SOVERSION           ${PROJECT_VERSION_MAJOR}
@@ -41,10 +42,17 @@ set_target_properties(mqtta PROPERTIES
     C_STANDARD          99
     C_STANDARD_REQUIRED ON
 )
+target_include_directories(mqtta
+	PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+	PRIVATE
+		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/mqtt-tools>
+)
 target_link_libraries(mqtta
-    mosqhelper
-    "${CONFIG_LIBRARY}"
-    "${MOSQUITTO_LIBRARY}"
+	PRIVATE
+		mqtta::mosqhelper
+		"${CONFIG_LIBRARY}"
+		"${MOSQUITTO_LIBRARY}"
 )
 install(TARGETS mqtta
 	EXPORT ${PROJECT_NAME}-targets

--- a/lib/mosqhelper.c
+++ b/lib/mosqhelper.c
@@ -4,7 +4,7 @@
  * License-Filename: LICENSES/MIT.txt
  */
 
-#include "mosqhelper.h"
+#include "mqtt-tools/mosqhelper.h"
 
 #include <errno.h>
 

--- a/lib/mqtta.c
+++ b/lib/mqtta.c
@@ -4,7 +4,7 @@
  * License-Filename: LICENSES/MIT.txt
  */
 
-#include "mqtta.h"
+#include "mqtt-tools/mqtta.h"
 
 #include <errno.h>
 #include <stddef.h>
@@ -15,7 +15,7 @@
 
 #include <mosquitto.h>
 
-#include "mosqhelper.h"
+#include "mqtt-tools/mosqhelper.h"
 #include "mqtta-build.h"
 
 


### PR DESCRIPTION
In so called Modern CMake it is good practice to avoid global
manipulation of include directories and set include directories as
target properties. This way those can be exported later and user can
just depend on the namespaced target names. We declare those as alias
for internal use (we will need that e.g. for unit tests).