### PR TITLE
RFC: test: Introduce unit testing with cmocka

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
     - libmosquitto-dev
     - libconfig-dev
+    - libcmocka-dev 
 
 compiler:
   - clang
@@ -20,4 +21,4 @@ before_script:
   - mkdir build
   - cd build
 
-script: cmake -DCMAKE_C_FLAGS='-Wall -Wextra -Wcast-align' .. && make
+script: cmake -DCMAKE_C_FLAGS='-Wall -Wextra -Wcast-align' -DMQTTA_WITH_TESTS=ON .. && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ install(EXPORT ${PROJECT_NAME}-targets
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
+# Tests
+option(MQTTA_WITH_TESTS "Unit tests for mqtta." OFF)
+if(MQTTA_WITH_TESTS)
+	add_subdirectory(test)
+endif(MQTTA_WITH_TESTS)
+
 # Documentation
 find_package(Doxygen)
 if(DOXYGEN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2017,2018 Stefan Haun, Netz39 e.V., and mqtta contributors
+# Copyright 2016–2019 Stefan Haun, Netz39 e.V., and mqtta contributors
 #
 # SPDX-License-Identifier: MIT
 # License-Filename: LICENSES/MIT.txt
@@ -56,8 +56,10 @@ install(EXPORT ${PROJECT_NAME}-targets
 # Tests
 option(MQTTA_WITH_TESTS "Unit tests for mqtta." OFF)
 if(MQTTA_WITH_TESTS)
-	add_subdirectory(test)
-endif(MQTTA_WITH_TESTS)
+	enable_testing()
+	include(CTest)
+	add_subdirectory("test")
+endif()
 
 # Documentation
 find_package(Doxygen)

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ apt-get install libmosquitto-dev
 apt-get install libconfig-dev
 ```
 
+If you want to build and run unit tests:
+```
+apt-get install libcmocka-dev
+```
+
 Not yet used:
 ```
 apt-get install libpthread-stubs0-dev
@@ -30,6 +35,9 @@ apt-get install libpopt-dev
 
 ## Usage
 The mqtt-clock.c shows a simple example of a (not yet daemonizied) agent that provides the current time over different MQTT topics. There is no reaction to incoming messages yet.
+
+### Unit Tests
+mqtt-tools uses [cmocka](https://cmocka.org/) for unit testing. To build with unit tests, set the CMake variable `MQTT_WITH_TESTS` to 'ON'. To run the tests, just call `ctest` in your build directory or directly call the test executables built.
 
 ## Status
 This is a very basic first go. Some parts of the API are working, but it is clearly visible that work needs to be done; in the API and the implementation. Contributions are welcome.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Stefan Haun, Netz39 e.V., and mqtta contributors
+# Copyright 2017,2018 Stefan Haun, Netz39 e.V., and mqtta contributors
 #
 # SPDX-License-Identifier: MIT
 # License-Filename: LICENSES/MIT.txt
@@ -15,6 +15,6 @@ add_executable(mqtta-test-null
 target_link_libraries(mqtta-test-null
 	"${CMOCKA_LIBRARY}"
 )
-add_test(test_null
-	mqtta-test-null
+add_test(NAME test_null
+	COMMAND mqtta-test-null
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,21 @@ add_executable(mqtta-test-null
 target_link_libraries(mqtta-test-null
 	"${CMOCKA_LIBRARIES}"
 )
-add_test(NAME test_null
+add_test(NAME mqtta-null
 	COMMAND mqtta-test-null
+)
+
+add_executable(mqtta-test-basic
+	mqtta-test-basic.c
+)
+target_include_directories(mqtta-test-basic
+	PRIVATE
+		${PROJECT_BINARY_DIR}/include/mqtt-tools
+)
+target_link_libraries(mqtta-test-basic
+	"${CMOCKA_LIBRARIES}"
+	mqtta::mqtta
+)
+add_test(NAME mqtta-basic
+	COMMAND mqtta-test-basic
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright 2017 Stefan Haun, Netz39 e.V., and mqtta contributors
+#
+# SPDX-License-Identifier: MIT
+# License-Filename: LICENSES/MIT.txt
+#
+
+find_library(CMOCKA_LIBRARY NAMES cmocka)
+
+enable_testing()
+
+add_executable(mqtta-test-null
+	mqtta-test-null.c
+)
+target_link_libraries(mqtta-test-null
+	"${CMOCKA_LIBRARY}"
+)
+add_test(test_null
+	mqtta-test-null
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,13 +5,13 @@
 # License-Filename: LICENSES/MIT.txt
 #
 
-find_library(CMOCKA_LIBRARY NAMES cmocka)
+find_package(cmocka CONFIG REQUIRED)
 
 add_executable(mqtta-test-null
 	mqtta-test-null.c
 )
 target_link_libraries(mqtta-test-null
-	"${CMOCKA_LIBRARY}"
+	"${CMOCKA_LIBRARIES}"
 )
 add_test(NAME test_null
 	COMMAND mqtta-test-null

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,11 @@
 #
-# Copyright 2017,2018 Stefan Haun, Netz39 e.V., and mqtta contributors
+# Copyright 2017–2019 Stefan Haun, Netz39 e.V., and mqtta contributors
 #
 # SPDX-License-Identifier: MIT
 # License-Filename: LICENSES/MIT.txt
 #
 
 find_library(CMOCKA_LIBRARY NAMES cmocka)
-
-enable_testing()
 
 add_executable(mqtta-test-null
 	mqtta-test-null.c

--- a/test/mqtta-test-basic.c
+++ b/test/mqtta-test-basic.c
@@ -1,0 +1,39 @@
+/*******************************************************************//**
+ * \file		mqtta-test-basic.c
+ *
+ * \brief		Basic unit tests for mqtta library.
+ *
+ * \author		Alexander Dahl <alex@netz39.de>
+ *
+ * SPDX-License-Identifier: MIT
+ * License-Filename: LICENSES/MIT.txt
+ *
+ * \copyright	2019 Alexander Dahl, Netz39 e.V., and mqtta contributors
+ **********************************************************************/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <mqtt-tools/mqtta.h>
+
+#include "mqtta-build.h"
+
+static void version(void **state) {
+    const char *result;
+
+    (void) state; /* unused */
+
+    result = mqtta_version();
+
+    assert_non_null(result);
+    assert_string_equal(result, MQTTA_VERSION);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(version),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/mqtta-test-null.c
+++ b/test/mqtta-test-null.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSES/Apache-2.0.txt
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+/* A test case that does nothing and succeeds. */
+static void null_test_success(void **state) {
+    (void) state; /* unused */
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(null_test_success),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Unit testing involves some quite repetitive tasks. While CMake has a nice tool called CTest, which is somewhat limited in what it can do however. You still need to write your tests in C and a unit testing framework can help a lot. [cmocka](https://cmocka.org/) can do that. It has functions and macros for assertions, setup and teardown, and especially for mocking functions (not all of those used here, yet). 

The actual test count is somewhat distributed. So cmocka will run a number of tests in one executable and CTest will count one test execution per executable, but in the end all tests are executed and failures are caught by both. You might get around that by making one executable per unit test, but that's more boilerplate than necessary IMHO.

This series reflects the process of setting up those unit tests for the project. You might find the individual patches could be squashed or split up or reordered. Don't hesitate to comment and request changes.